### PR TITLE
fix: propagate fast and profile options

### DIFF
--- a/start.js
+++ b/start.js
@@ -13,7 +13,7 @@ module.exports = async (kernel) => {
           },
           path: "app",                // Edit this to customize the path to start the shell from
           message: [
-            "python wgp.py --multiple-images {{args.compile ? '--compile' : ''}}"
+            "python wgp.py --multiple-images {{args.profile ? '--profile ' + args.profile : ''}} {{args.fast ? '--fast' : ''}} {{args.compile ? '--compile' : ''}}"
             //"python wgp.py --multiple-images --profile {{args.profile}} {{args.mode ? args.mode : ''}} {{args.compile ? '--compile' : ''}} {{args.attention ? args.attention : ''}}",    // Edit with your custom commands
             //"python gradio_server.py --multiple-images --profile {{args.profile}} {{args.mode ? args.mode : ''}} {{args.compile ? '--compile' : ''}} {{args.attention ? args.attention : ''}}",    // Edit with your custom commands
           ],


### PR DESCRIPTION
## Summary
- respect `fast` and `profile` flags in start script so web UI options work

## Testing
- `node --check start.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae89ac8994833291b82a2e80e7c7da